### PR TITLE
Update readme and add license file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem "tilt", "~> 2.2"
 group :development do
   gem "pry", "~> 0.14.2"
   gem "rspec", "~> 3.12"
-  gem "rubocop", require: false
   gem "rubocop-rspec", require: false
   gem "standard", ">= 1.0", require: false
   gem "standard-performance", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,6 @@ DEPENDENCIES
   redcarpet (~> 3.6)
   rouge (~> 4.1)
   rspec (~> 3.12)
-  rubocop
   rubocop-rspec
   standard (>= 1.0)
   standard-performance

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright 2023 Alex Musayev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,25 @@
-Public notes
+# Public notes automation
 
-Scripts:
+**Disclaimer:** This project is a single-purpose software built for personal use. It does not include a user manual and does not guarantee backward compatibility. I never intended to distribute this code, so there is no gemspec, public releases, changes history, or versioning. Very minimal customizability either.
 
-- `bin/build` — build the site.
-- `bin/serve` — run local HTTP server to preview the site.
+## Usage
 
-Environment variables:
+Setup:
 
-- `NOTES_PATH` — primary notes directory.
+```bash
+brew install caddy
+bundle
+yarn && yarn build
+```
 
-Note file name format is `YYYYMMDD_NNNN.md`, where
+Build everything:
 
-- `YYYYMMDD` — note creation date.
-- `NNNN` — unique number with zero indentation, preventing note id collisions.
+```bash
+NOTES_CONFIGURATION_PATH=~/src/notes/configuration.yml ~/src/notes/bin/build
+```
 
-Frontend assets:
+Run local HTTP server to preview the site:
 
-- `yarn` — install frontend dependencies.
-- `yarn build` — build stylesheets.
+```bash
+bin/serve
+```


### PR DESCRIPTION
Also remove `rubocop` from direct dependencies. `standard` includes it anyway.