### PR TITLE
Add safelist to Tailwind config

### DIFF
--- a/lib/notes/components.rb
+++ b/lib/notes/components.rb
@@ -1,3 +1,4 @@
+# NOTE: Make sure to update Tailwind safelist if some CSS classes are used here
 class Notes::Components
   class << self
     def tags_list(tags:, current_tag: nil)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,22 @@ module.exports = {
   content: [
     "../notes/templates/**/*.html.erb"
   ],
+  safelist: [
+    /^m[lrxy]-\d+/,
+    /^p[lrxy]-\d+/,
+    "bg-slate-100",
+    "bg-slate-500",
+    "block",
+    "border",
+    "border-slate-200",
+    "border-slate-600",
+    "font-normal",
+    "no-underline",
+    "rounded-md",
+    "text-slate-100",
+    "text-slate-400",
+    "text-slate-800",
+  ],
   theme: {
     extend: {
       typography: {
@@ -23,4 +39,3 @@ module.exports = {
     require('@tailwindcss/typography')
   ],
 }
-

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,8 +4,6 @@ module.exports = {
     "../notes/templates/**/*.html.erb"
   ],
   safelist: [
-    /^m[lrxy]-\d+/,
-    /^p[lrxy]-\d+/,
     "bg-slate-100",
     "bg-slate-500",
     "block",
@@ -18,6 +16,12 @@ module.exports = {
     "text-slate-100",
     "text-slate-400",
     "text-slate-800",
+    {
+      "pattern": /m(l|r|x|y)-.+/,
+    },
+    {
+      "pattern": /p(l|r|x|y)-.+/,
+    },
   ],
   theme: {
     extend: {


### PR DESCRIPTION
This should fix the missing Tailwind CSS classes that are used in the `Notes::Components` but not present in HTML/ERB templates.

Margin and padding modifiers have been added preventively.