### PR TITLE
Clean-up the templates

### DIFF
--- a/lib/notes/components.rb
+++ b/lib/notes/components.rb
@@ -2,7 +2,7 @@
 class Notes::Components
   class << self
     def tags_list(tags:, current_tag: nil)
-      tags.sort.map { tag(tag: _1, highlight: _1 == current_tag) }.join
+      tags.sort.map { tag(tag: _1) }.join
     end
 
     def pages_list(pages)

--- a/templates/index.html.erb
+++ b/templates/index.html.erb
@@ -1,7 +1,7 @@
-<main>
-  <div class="flex flex-row flex-wrap items-stretch !my-8">
-    <%= components.tags_list(tags: site.tags) %>
-  </div>
-  <p>Notes:</p>
-  <%= components.pages_list(site.note_pages) %>
-</main>
+<div class="flex flex-row flex-wrap items-stretch !my-8">
+  <%= components.tags_list(tags: site.tags) %>
+</div>
+
+<p>Notes:</p>
+
+<%= components.pages_list(site.note_pages) %>

--- a/templates/tag.html.erb
+++ b/templates/tag.html.erb
@@ -1,7 +1,7 @@
-<main>
-  <div class="flex flex-row flex-wrap items-stretch !my-8">
-    <%= components.tags_list(tags: site.tags, current_tag: page.tag) %>
-  </div>
-  <p>Tagged with <a href="/tags/<%= page.tag %>"><%= page.tag %></a>:</p>
-  <%= components.pages_list(site.tagged_pages(page.tag)) %>
-</main>
+<div class="flex flex-row flex-wrap items-stretch !my-8">
+  <%= components.tags_list(tags: site.tags, current_tag: page.tag) %>
+</div>
+
+<p>Tagged with <a href="/tags/<%= page.tag %>"><%= page.tag %></a>:</p>
+
+<%= components.pages_list(site.tagged_pages(page.tag)) %>


### PR DESCRIPTION
- Remove redundant `main` element from the templates.
- Remove tag highlighting, since it is hard to override the styles in the Tailwind configuration.