### PR TITLE
Define canonical URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Upgrade packages:
 yarn upgrade --latest
 ```
 
+Run the tests:
+
+```bash
+rspec
+```
+
 Build CSS:
 
 ```bash

--- a/lib/notes/note_page.rb
+++ b/lib/notes/note_page.rb
@@ -4,7 +4,6 @@ class Notes::NotePage < Notes::Page
     :short_uid,
     :slug,
     :tags,
-    :title,
     :body,
     :url
   )
@@ -15,7 +14,6 @@ class Notes::NotePage < Notes::Page
     @short_uid ||= attributes[:short_uid]
     @slug ||= attributes[:slug]
     @tags ||= attributes[:tags]
-    @title ||= attributes[:title]
     @body ||= attributes[:body]
     @url ||= attributes[:url]
   end

--- a/lib/notes/note_page_builder.rb
+++ b/lib/notes/note_page_builder.rb
@@ -19,6 +19,7 @@ class Notes::NotePageBuilder
       url: url,
       local_path: local_path,
       public_path: public_path,
+      canonical_path: public_path,
       attachments: attachments
     )
   end

--- a/lib/notes/page.rb
+++ b/lib/notes/page.rb
@@ -1,11 +1,20 @@
 class Notes::Page
-  attr_reader :template, :layout, :local_path, :public_path, :published_at
+  attr_reader(
+    :template,
+    :layout,
+    :local_path,
+    :public_path,
+    :canonical_path,
+    :published_at,
+    :title
+  )
 
   def initialize(attributes = {})
     @template = attributes[:template]
     @layout = attributes[:layout]
     @local_path = attributes[:local_path]
     @public_path = attributes[:public_path]
+    @canonical_path = attributes[:canonical_path]
     @attachments = attributes[:attachments]
     @published_at = attributes[:published_at]
     @title = attributes[:title]

--- a/lib/notes/page.rb
+++ b/lib/notes/page.rb
@@ -8,6 +8,7 @@ class Notes::Page
     @public_path = attributes[:public_path]
     @attachments = attributes[:attachments]
     @published_at = attributes[:published_at]
+    @title = attributes[:title]
   end
 
   def attachments

--- a/lib/notes/site.rb
+++ b/lib/notes/site.rb
@@ -36,6 +36,7 @@ class Notes::Site
       Notes::TagPage.new(
         local_path: "tags/#{tag}/index.html",
         public_path: "tags/#{tag}",
+        canonical_path: "tags/#{tag}",
         tag: tag
       )
     end

--- a/spec/notes/images_cache_spec.rb
+++ b/spec/notes/images_cache_spec.rb
@@ -11,10 +11,14 @@ RSpec.describe Notes::ImagesCache do
   it "downloads an image to local cache" do
     Dir.mktmpdir do |assets_path|
       allow(Notes::Configuration).to receive(:assets_path).and_return(assets_path)
-      result = images_cache.get(url: cleanshot_url, scope: "SCOPE")
-      expect(File).to exist(File.join(assets_path, result))
+
+      result = images_cache.get(url: cleanshot_url, page_uid: "PAGE_UID")
+      page_uid = result.fetch("page_uid")
+      file_name = result.fetch("file_name")
+
+      expect(File).to exist(File.join(assets_path, page_uid, file_name))
       expect(File).to exist(File.join(assets_path, "index.json"))
-      expect(File.extname(result)).to eq(".jpg")
+      expect(File.extname(file_name)).to eq(".jpg")
     end
   end
 end

--- a/spec/notes/markdown_renderer_spec.rb
+++ b/spec/notes/markdown_renderer_spec.rb
@@ -7,10 +7,11 @@ RSpec.describe Notes::MarkdownRenderer do
   end
 
   let(:result) { Redcarpet::Markdown.new(renderer).render(markdown_source) }
+
   let(:process_image) do
     lambda do |url|
       raise unless url == "https://example.com/image.jpg"
-      "PROCESSED_IMAGE_URL"
+      { "file_name" => "PROCESSED_IMAGE_URL" }
     end
   end
 

--- a/templates/layout.html.erb
+++ b/templates/layout.html.erb
@@ -6,8 +6,11 @@
   <meta name="author" content="<%= configuration.author_name %>">
   <meta name="description" content="" />
   <title><%= [page.title, configuration.site_name].compact.join(" - ") %></title>
+  <% if page.canonical_path %>
+    <link rel="canonical" href="<%= "#{configuration.site_root_url}#{page.canonical_path}" %>">
+  <% end %>
   <link rel="alternate" type="application/rss+xml" title="<%= configuration.site_name %>" href="<%= configuration.feed_url %>">
-  <link rel="icon" href="data:," />
+  <link rel="icon" href="data:,">
   <link href="/style.css" rel="stylesheet" type="text/css">
   <style><%= Rouge::Themes::Github.render(scope: ".highlight") %></style>
   <script src="https://cdn.counter.dev/script.js" data-id="d94a1231-14bd-47f9-ad32-cf1a9b40d2a5" data-utcoffset="2"></script>

--- a/templates/layout.html.erb
+++ b/templates/layout.html.erb
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <meta name="author" content="<%= configuration.author_name %>">
   <meta name="description" content="" />
-  <title><%= [page.respond_to?(:title) ? page.title : nil, configuration.site_name].compact.join(" - ") %></title>
+  <title><%= [page.title, configuration.site_name].compact.join(" - ") %></title>
   <link rel="alternate" type="application/rss+xml" title="<%= configuration.site_name %>" href="<%= configuration.feed_url %>">
   <link rel="icon" href="data:," />
   <link href="/style.css" rel="stylesheet" type="text/css">


### PR DESCRIPTION
- Add `<link rel="canonical">` tag to the layout.
- Move title attribute to the basic `Page` class to avoid weird condition in the templates.
- Fix tests.