### PR TITLE
Fix publish-notes for Ruby 3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,5 @@ group :development do
   gem "webmock", "~> 3.18"
   gem "yaml-lint", "~> 0.1.2", require: false
 end
+
+gem "http", "~> 6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,10 +10,17 @@ GEM
       bigdecimal
       rexml
     diff-lcs (1.5.1)
+    domain_name (0.6.20240107)
     hashdiff (1.1.0)
+    http (6.0.2)
+      http-cookie (~> 1.0)
+      llhttp (~> 0.6.1)
+    http-cookie (1.1.0)
+      domain_name (~> 0.5)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
+    llhttp (0.6.1)
     method_source (1.1.0)
     parallel (1.24.0)
     parser (3.3.1.0)
@@ -95,8 +102,11 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
+  arm64-darwin-24
 
 DEPENDENCIES
+  http (~> 6.0)
   pry (~> 0.14.2)
   redcarpet (~> 3.6)
   rouge (~> 4.1)

--- a/lib/notes/note_page_builder.rb
+++ b/lib/notes/note_page_builder.rb
@@ -57,7 +57,8 @@ class Notes::NotePageBuilder
       autolink: true,
       strikethrough: true,
       space_after_headers: true,
-      highlight: true
+      highlight: true,
+      tables: true
     ).render(source_content.gsub(FRONTMATTER_PATETRN, ""))
   end
 

--- a/lib/notes/note_page_builder.rb
+++ b/lib/notes/note_page_builder.rb
@@ -103,7 +103,7 @@ class Notes::NotePageBuilder
   end
 
   def metadata
-    @metadata ||= frontmatter? ? YAML.safe_load(source_content) : {}
+    @metadata ||= frontmatter? ? YAML.safe_load(source_content.match(FRONTMATTER_PATETRN)[1], permitted_classes: [Date, Time]) : {}
   end
 
   def frontmatter?


### PR DESCRIPTION
## Summary

- Add missing `http` gem dependency
- Fix YAML frontmatter parsing for Ruby 3.1+: extract only the frontmatter block before passing to `safe_load`, and permit `Date`/`Time` classes (Psych 4+ requires explicit allowlisting)
- Enable table rendering in Redcarpet (`tables: true`)

## Test plan

- [ ] Run `publish-notes` and confirm it completes without errors
- [ ] Verify tables render correctly in published notes