### PR TITLE
Add a note on notescli supersede

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Public notes automation
 
+👉 Superseded by [notespub]([url](https://github.com/dreikanter/notespub)).
+
 **Disclaimer:** This project is _single-purpose software_ built for personal use. It is not a product, does not include a user manual, and does not guarantee backward compatibility. I don't intend to distribute this code, so there is no gemspec, public releases, change log, or versioning. There is very minimal customizability by design.
 
 ## Usage


### PR DESCRIPTION
Added a note indicating the project is superseded by notespub.